### PR TITLE
Project Page and UI polish

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -12,6 +12,7 @@ const nextConfig: NextConfig = {
   turbopack: {
     root: import.meta.dirname,
   },
+  allowedDevOrigins: ['192.168.0.103'],
   /* config options here */
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@sanity/image-url": "^1.1.0",
         "@sanity/orderable-document-list": "^1.5.0",
         "@sanity/vision": "^5.8.1",
+        "framer-motion": "^12.38.0",
         "next": "16.2.4",
         "next-sanity": "^12.1.0",
         "react": "19.2.4",
@@ -11468,13 +11469,13 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "12.34.3",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.34.3.tgz",
-      "integrity": "sha512-v81ecyZKYO/DfpTwHivqkxSUBzvceOpoI+wLfgCgoUIKxlFKEXdg0oR9imxwXumT4SFy8vRk9xzJ5l3/Du/55Q==",
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
+      "integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
       "license": "MIT",
       "dependencies": {
-        "motion-dom": "^12.34.3",
-        "motion-utils": "^12.29.2",
+        "motion-dom": "^12.38.0",
+        "motion-utils": "^12.36.0",
         "tslib": "^2.4.0"
       },
       "peerDependencies": {
@@ -13901,18 +13902,18 @@
       }
     },
     "node_modules/motion-dom": {
-      "version": "12.34.3",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.34.3.tgz",
-      "integrity": "sha512-sYgFe+pR9aIM7o4fhs2aXtOI+oqlUd33N9Yoxcgo1Fv7M20sRkHtCmzE/VRNIcq7uNJ+qio+Xubt1FXH3pQ+eQ==",
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
+      "integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
       "license": "MIT",
       "dependencies": {
-        "motion-utils": "^12.29.2"
+        "motion-utils": "^12.36.0"
       }
     },
     "node_modules/motion-utils": {
-      "version": "12.29.2",
-      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.29.2.tgz",
-      "integrity": "sha512-G3kc34H2cX2gI63RqU+cZq+zWRRPSsNIOjpdl9TN4AQwC4sgwYPl/Q/Obf/d53nOm569T0fYK+tcoSV50BWx8A==",
+      "version": "12.36.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
+      "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
       "license": "MIT"
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@sanity/image-url": "^1.1.0",
     "@sanity/orderable-document-list": "^1.5.0",
     "@sanity/vision": "^5.8.1",
+    "framer-motion": "^12.38.0",
     "next": "16.2.4",
     "next-sanity": "^12.1.0",
     "react": "19.2.4",

--- a/src/app/components/Homepage.tsx
+++ b/src/app/components/Homepage.tsx
@@ -29,7 +29,13 @@ const Homepage: React.FC<ProjectProps> = ({ portfolio }) => {
     }
 
     sections.forEach((section, i) => {
-      if (i === 0) return;
+      if (i === 0) {
+        gsap.fromTo(section,
+          { opacity: 0 },
+          { opacity: 1, duration: 0.6, ease: "power2.out", delay: 0.2 }
+        );
+        return;
+      }
 
       gsap.fromTo(section,
         { opacity: 0 },
@@ -74,7 +80,6 @@ const Homepage: React.FC<ProjectProps> = ({ portfolio }) => {
         <Row
           key={`${proj._id}-${index}`}
           project={proj}
-          index={index}
         />
       ))}
     </div>

--- a/src/app/components/Nav.tsx
+++ b/src/app/components/Nav.tsx
@@ -1,41 +1,32 @@
 
 import Link from "next/link";
 import NameBanner from "../../../public/nameBanner";
+import { forwardRef } from "react";
 
 interface NavProps {
   page: string
 }
 
-const Nav = ({page}: NavProps) => {
-
-  const whiteBannerPages = [
-    "info",
-    "home",
-    "project"
-  ];
-
-  const whiteLinksPages = [
-    "home",
-    "project",
-  ];
+const Nav = forwardRef<HTMLElement, NavProps>(({ page }, ref) => {
+  const whiteBannerPages = ["info", "home", "project"];
+  const whiteLinksPages = ["home", "project"];
 
   const bannerColor = whiteBannerPages.includes(page) ? "white" : "black";
-
   const linksColor = whiteLinksPages.includes(page) ? "text-white" : "text-black";
 
   return (
-    <nav className={`fixed z-10 w-full flex flex-col md:grid grid-cols-2 gap-0 pt-[5.4vh] px-[12vw] md:px-10 md:pt-[52px]`}>
+    <nav ref={ref} className={`fixed z-10 w-full flex flex-col md:grid grid-cols-2 gap-0 pt-[5.4vh] px-6 md:px-10 md:pt-[52px] transition-transform duration-300 ease-in-out`}>
       <div className="w-full md:w-2/3">
-        <NameBanner
-          color={bannerColor}
-        />
+        <NameBanner color={bannerColor} />
       </div>
       <div className={`${page === "info" ? "text-white md:text-black" : linksColor} text-center mt-5 md:m-0 md:relative md:top-8 h-fit md:flex md:justify-end md:pr-16`}>
         <Link className="" href={"/info"}>INFO</Link>
         <Link className="ml-12" href={"/portfolio"}>PROJECTS</Link>
       </div>
     </nav>
-  )
-}
+  );
+});
+
+Nav.displayName = "Nav";
 
 export default Nav;

--- a/src/app/components/PageTransition.tsx
+++ b/src/app/components/PageTransition.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { usePathname } from "next/navigation";
+
+export default function PageTransition({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+
+  return (
+    <motion.div
+      key={pathname}
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.7, ease: "easeInOut" }}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/src/app/components/PortfolioGrid.tsx
+++ b/src/app/components/PortfolioGrid.tsx
@@ -63,6 +63,7 @@ const PortfolioGrid: React.FC<PortfolioPageProps> = ({ portfolio }) => {
     <div
       ref={scrollRef}
       className="relative w-full h-screen overflow-y-scroll pb-12"
+      style={{ "--nav-h": `${navHeight}px` } as React.CSSProperties}
     >
       <PortfolioGridNav ref={navRef} />
       <div className="grid grid-cols-1 md:grid-cols-3 gap-12 px-8" style={{ paddingTop: `calc(var(--nav-h) + 2.5rem)` }}>

--- a/src/app/components/PortfolioGrid.tsx
+++ b/src/app/components/PortfolioGrid.tsx
@@ -63,7 +63,6 @@ const PortfolioGrid: React.FC<PortfolioPageProps> = ({ portfolio }) => {
     <div
       ref={scrollRef}
       className="relative w-full h-screen overflow-y-scroll pb-12"
-      style={{ "--nav-h": `${navHeight}px` } as React.CSSProperties}
     >
       <PortfolioGridNav ref={navRef} />
       <div className="grid grid-cols-1 md:grid-cols-3 gap-12 px-8" style={{ paddingTop: `calc(var(--nav-h) + 2.5rem)` }}>

--- a/src/app/components/ProjectPage.tsx
+++ b/src/app/components/ProjectPage.tsx
@@ -4,7 +4,7 @@ import { ProjectQueryResult } from "@/sanity/types";
 import ProjectPageGallery from "./ProjectPageGallery";
 import { AllImageArray } from "../lib/types";
 
-import { useRef, useEffect, useState } from "react";
+import { useRef, useEffect, useSyncExternalStore } from "react";
 
 import { gsap } from "gsap";
 import { useGSAP } from "@gsap/react";
@@ -53,17 +53,14 @@ function buildGroups(images: AllImageArray[]): ImageGroup[] {
 }
 
 const useScreenWidth = () => {
-  const [screenWidth, setScreenWidth] = useState(() =>
-    typeof window !== "undefined" ? window.innerWidth : 1024
-);
-
-  useEffect(() => {
-    const handleResize = () => setScreenWidth(window.innerWidth);
-    window.addEventListener("resize", handleResize);
-    return () => window.removeEventListener("resize", handleResize);
-  }, [])
-
-  return screenWidth;
+  return useSyncExternalStore(
+    (callback) => {
+      window.addEventListener("resize", callback);
+      return () => window.removeEventListener("resize", callback);
+    },
+    () => window.innerWidth,
+    () => 1024
+  );
 }
 
 export default function ProjectPage({project}: ProjectPageProps) {

--- a/src/app/components/ProjectPage.tsx
+++ b/src/app/components/ProjectPage.tsx
@@ -4,7 +4,7 @@ import { ProjectQueryResult } from "@/sanity/types";
 import ProjectPageGallery from "./ProjectPageGallery";
 import { AllImageArray } from "../lib/types";
 
-import { useRef, useEffect, useSyncExternalStore } from "react";
+import { useRef, useSyncExternalStore } from "react";
 
 import { gsap } from "gsap";
 import { useGSAP } from "@gsap/react";

--- a/src/app/components/ProjectPage.tsx
+++ b/src/app/components/ProjectPage.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { ProjectQueryResult } from "@/sanity/types";
-import ProjectPageNav from "./ProjectPageNav";
 import ProjectPageGallery from "./ProjectPageGallery";
 import { AllImageArray } from "../lib/types";
 
@@ -10,6 +9,7 @@ import { useRef, useEffect, useState } from "react";
 import { gsap } from "gsap";
 import { useGSAP } from "@gsap/react";
 import ScrollTrigger from "gsap/ScrollTrigger";
+import Nav from "./Nav";
 gsap.registerPlugin(ScrollTrigger);
 
 
@@ -23,6 +23,13 @@ export interface ImageGroup {
   type: GroupType;
   images: AllImageArray[];
 };
+
+interface PhotoCred {
+  photogName?: string;
+  photogUrl?: string;
+  _key: string;
+}
+
 
 function buildGroups(images: AllImageArray[]): ImageGroup[] {
   const groups: ImageGroup[] = [];
@@ -62,24 +69,12 @@ const useScreenWidth = () => {
 export default function ProjectPage({project}: ProjectPageProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const navRef = useRef<HTMLElement>(null);
-  const [navHeight, setNavHeight] = useState(0);
 
   const windowWidth = useScreenWidth();
 
   const isMobile = windowWidth < 768
 
   const groups = buildGroups(project?.photos ?? []);
-
-
-  useEffect(() => {
-    const nav = navRef.current;
-    if (!nav) return;
-
-    const rO = new ResizeObserver(() => setNavHeight(nav.offsetHeight));
-
-    rO.observe(nav);
-    return () => rO.disconnect();
-  }, []);
 
   useGSAP(() => {
     const container = scrollRef.current;
@@ -142,27 +137,54 @@ export default function ProjectPage({project}: ProjectPageProps) {
     dependencies: [groups]
   })
 
+  const photoCreditsElement = (creditList: PhotoCred[]) => {
+    return (
+      <div
+        className=""
+      >
+        PHOTO{creditList.length > 1 ? "S" : ""} BY {
+          creditList.map((cred, i) => {
+            return (
+              cred.photogUrl ? (
+                <span key={cred._key}>{i > 0 && <span> & </span>}<a className="folioPicCred" href={cred.photogUrl} target="_blank">{cred.photogName}</a></span>) : (<span key={cred._key}>{i > 0 && <span> & </span>}<span className="folioPicCred" key={cred._key}>{cred.photogName}</span></span>
+              )
+            )
+          })
+        }
+      </div>
+    )
+  }
+
   return (
     <div
       ref={scrollRef}
-      className="relative w-full h-screen overflow-y-scroll"
-      style={{ "--nav-h": `${navHeight}px`} as React.CSSProperties }
+      className="relative w-full h-screen overflow-y-scroll relative"
     >
-      <ProjectPageNav
-        projectName={project?.projectName ?? ""}
-        location={project?.projectLocation ?? ""}
-        projectType={project?.projectType ?? null}
-        photoCredit={project?.photoCredit ?? null}
+      <Nav
+        page="project"
         ref={navRef}
-        />
+      />
       {project?.photos &&
         <ProjectPageGallery
           isMobile={isMobile}
           groups={groups}
           projectName={project.projectName ?? null}
-          firstRowHeight={`calc(100vh - ${navHeight}px)`}
         />
       }
+      <div className="text-white z-[100] uppercase px-6 md:px-10 fixed bottom-6 md:bottom-10">
+        {project?.projectName &&
+          <p>{project?.projectName}</p>
+        }
+        {project?.projectLocation &&
+          <p>{project?.projectLocation}</p>
+        }
+        {project?.projectType &&
+          <p>{project?.projectType}</p>
+        }
+        {project?.photoCredit &&
+          photoCreditsElement(project?.photoCredit)
+        }
+      </div>
     </div>
   )
 }

--- a/src/app/components/ProjectPageGallery.tsx
+++ b/src/app/components/ProjectPageGallery.tsx
@@ -34,7 +34,7 @@ export default function ProjectPageGallery({groups, projectName, isMobile}: Gall
                   src={urlFor(group.images[0])
                     .width(1000)
                     .dpr(2)
-                    .quality(75)
+                    .quality(100)
                     .url()
                   }
                   placeholder="blur"
@@ -42,7 +42,7 @@ export default function ProjectPageGallery({groups, projectName, isMobile}: Gall
                   sizes="100vw"
                   alt={`Photo of ${projectName ?? "project"}`}
                   blurDataURL={group.images[0].asset?.metadata?.lqip}
-                  quality={75}
+                  quality={100}
                   className="object-cover"
                   priority={groupIdx === 0}
                 />}

--- a/src/app/components/ProjectPageGallery.tsx
+++ b/src/app/components/ProjectPageGallery.tsx
@@ -21,12 +21,14 @@ export default function ProjectPageGallery({groups, projectName, isMobile}: Gall
 
         // full row, one img per row
         if (group.type === "full") {
+          const aspectRatio = group.images[0]?.asset?.metadata?.dimensions?.aspectRatio;
           return (
             <div
               key={groupIdx}
-              className="relative w-full row h-screen"
+              className="relative w-full row"
               style={{
                 opacity: isFirst ? 1 : 0,
+                height: aspectRatio && !isMobile ? `calc(100vw / ${aspectRatio})` : "100vh",
                }}
             >
               <div className="relative w-full h-full">

--- a/src/app/components/ProjectPageGallery.tsx
+++ b/src/app/components/ProjectPageGallery.tsx
@@ -5,11 +5,10 @@ import { ImageGroup } from "./ProjectPage";
 interface GalleryProps {
   groups: ImageGroup[];
   projectName: string | null;
-  firstRowHeight: string;
   isMobile: boolean
 }
 
-export default function ProjectPageGallery({groups, projectName, firstRowHeight, isMobile}: GalleryProps) {
+export default function ProjectPageGallery({groups, projectName, isMobile}: GalleryProps) {
 
 
   return (
@@ -18,7 +17,6 @@ export default function ProjectPageGallery({groups, projectName, firstRowHeight,
     >
       {groups.map((group, groupIdx) => {
 
-        const rowHeight = groupIdx === 0 ? firstRowHeight : "100vh";
         const isFirst = groupIdx === 0;
 
         // full row, one img per row
@@ -26,11 +24,9 @@ export default function ProjectPageGallery({groups, projectName, firstRowHeight,
           return (
             <div
               key={groupIdx}
-              className="relative w-full row"
+              className="relative w-full row h-screen"
               style={{
-                height: rowHeight,
                 opacity: isFirst ? 1 : 0,
-                marginTop: isFirst ? `calc(100vh - ${firstRowHeight})` : 0,
                }}
             >
               <div className="relative w-full h-full">
@@ -61,8 +57,8 @@ export default function ProjectPageGallery({groups, projectName, firstRowHeight,
               group.images.map((img, idx) => (
                 <div
                   key={`${groupIdx}-${idx}`}
-                  className={`row w-full flex flex-col sm:flex-row md:hidden`}
-                  style={{ height: rowHeight, opacity: groupIdx === 0 ? 1 : 0 }}
+                  className={`row w-full flex flex-col sm:flex-row md:hidden h-screen`}
+                  style={{ opacity: groupIdx === 0 ? 1 : 0 }}
 
                 >
                   <div
@@ -95,8 +91,8 @@ export default function ProjectPageGallery({groups, projectName, firstRowHeight,
 
           return (
             <div
-              className="row w-full flex-row md:flex"
-              style={{ height: rowHeight, opacity: groupIdx === 0 ? 1 : 0 }}
+              className="row w-full flex-row md:flex h-screen"
+              style={{ opacity: groupIdx === 0 ? 1 : 0 }}
               data-snap="desktop"
               key={groupIdx}
             >
@@ -128,76 +124,6 @@ export default function ProjectPageGallery({groups, projectName, firstRowHeight,
             </div>
           )
         }
-        // return (
-
-        //   <Fragment key={groupIdx}>
-        //     {/* Desktop row: two images per row */}
-        //     <div
-        //       className={`hidden row w-full flex flex-col sm:flex-row ${group.images.length === 2 ? "flex flex-col" : "block"} md:block`}
-        //       style={{ height: rowHeight, opacity: groupIdx === 0 ? 1 : 0 }}
-        //       data-snap="desktop"
-        //     >
-        //       {group.images.map((img, idx) => (
-        //         <div
-        //           key={idx}
-        //           className="relative w-full h-full overflow-hidden sm:flex-1"
-        //         >
-        //           <div className="relative w-full h-full">
-        //             {img && <Image
-        //               src={urlFor(img)
-        //                 .width(1000)
-        //                 .dpr(2)
-        //                 .quality(75)
-        //                 .url()
-        //               }
-        //               placeholder="blur"
-        //               fill
-        //               sizes="100vw"
-        //               alt={`Photo of ${projectName ?? "project"}`}
-        //               blurDataURL={img.asset?.metadata?.lqip}
-        //               quality={100}
-        //               className="object-cover"
-        //               priority={groupIdx === 0}
-        //             />}
-        //           </div>
-        //         </div>
-        //       ))}
-        //     </div>
-
-        //     {/* Mobile: one full vh image per row */}
-        //     {group.images.map((img, idx) => (
-        //       <div
-        //         key={`${groupIdx}-${idx}`}
-        //         className={`row w-full flex flex-col sm:flex-row md:hidden mobileRow`}
-        //         style={{ height: rowHeight, opacity: groupIdx === 0 ? 1 : 0 }}
-        //         data-snap="mobile"
-        //       >
-        //         <div
-        //           className="relative w-full h-full overflow-hidden sm:flex-1"
-        //         >
-        //           <div className="relative w-full h-full">
-        //             {img && <Image
-        //               src={urlFor(img)
-        //                 .width(1000)
-        //                 .dpr(2)
-        //                 .quality(75)
-        //                 .url()
-        //               }
-        //               placeholder="blur"
-        //               fill
-        //               sizes="125vw"
-        //               alt={`Photo of ${projectName ?? "project"}`}
-        //               blurDataURL={img.asset?.metadata?.lqip}
-        //               quality={100}
-        //               className="object-cover"
-        //               priority={groupIdx === 0}
-        //             />}
-        //           </div>
-        //         </div>
-        //       </div>
-        //     ))}
-        //   </Fragment>
-        // );
       })}
     </div>
   );

--- a/src/app/components/ProjectPageGallery.tsx
+++ b/src/app/components/ProjectPageGallery.tsx
@@ -21,14 +21,12 @@ export default function ProjectPageGallery({groups, projectName, isMobile}: Gall
 
         // full row, one img per row
         if (group.type === "full") {
-          const aspectRatio = group.images[0]?.asset?.metadata?.dimensions?.aspectRatio;
           return (
             <div
               key={groupIdx}
-              className="relative w-full row"
+              className="relative w-full row h-screen"
               style={{
                 opacity: isFirst ? 1 : 0,
-                height: aspectRatio && !isMobile ? `calc(100vw / ${aspectRatio})` : "100vh",
                }}
             >
               <div className="relative w-full h-full">

--- a/src/app/components/Row.tsx
+++ b/src/app/components/Row.tsx
@@ -6,19 +6,15 @@ import Link from "next/link";
 
 interface RowProps {
   project: SinglePortfolioProject,
-  index: number,
 }
 
-const Row: React.FC<RowProps> = ({
-  project,
-  index,
-}) => {
+const Row: React.FC<RowProps> = ({ project }) => {
 
   return (
     project.projectName &&
     <Link
       className="row grid grid-cols-1 gap-0 md:grid-cols-2 relative h-screen relative"
-      style={{ opacity: index === 0 ? 1 : 0}}
+      style={{ opacity: 0 }}
         href={`/${encodeURIComponent(project.projectName)}`}
     >
       <div className={`left-img relative h-screen ${!project.photos?.[1] ? 'md:col-span-2' : ''}`}>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -52,6 +52,6 @@ body {
   transition: opacity 200ms cubic-bezier(.4, 0, .2, 1);
 }
 
-#tagline, p:first-of-type {
+#tagline p:first-of-type {
   margin-bottom: 1em;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -13,8 +13,7 @@
 }
 
 body {
-  /* background: #F8FAF5; */
-  /* background: #b9ceac; */
+  background-color: var(--bg-color);
   font-size: 13px;
   line-height: 14px;
   letter-spacing: -0.234px;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -61,7 +61,7 @@ export default async function RootLayout({
       </head>
       <body
         className={`${helveticaNeue.className} antialiased`}
-        style={{ backgroundColor: hex }}
+
       >
         <main>
           {children}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { SanityLive } from "@/sanity/lib/live";
 import { BgColorQueryResult } from "@/sanity/types";
 import { sanityFetch } from "./lib/sanityFetch";
 import { bgColorQuery } from "./lib/queries";
+import PageTransition from "./components/PageTransition";
 
 const helveticaNeue = localFont({
   src: [
@@ -64,7 +65,9 @@ export default async function RootLayout({
 
       >
         <main>
-          {children}
+          <PageTransition>
+            {children}
+          </PageTransition>
           <SanityLive />
         </main>
       </body>


### PR DESCRIPTION
## UI/UX Polish: Page Transitions, Navigation Consolidation & Entrance Animations

### Navigation consolidation
Replaced the separate `ProjectPageNav` component with the shared `Nav` component, giving all pages a unified header. Project metadata (name, location, type, photo credits) moved to a fixed bottom-left overlay on project pages. `Nav` now accepts a `ref` via `forwardRef` so the scroll-hide animation in `ProjectPage` can target it directly.

### Page transitions
Added `framer-motion` and a `PageTransition` client component that wraps the root layout. On every route change, the incoming page fades in over 0.7s using `usePathname` as the animation key.

### Homepage entrance animation
The first `Row` now fades in on mount (0.6s, 0.2s delay) via GSAP rather than appearing instantly. All rows start at `opacity: 0`; subsequent rows continue to be scroll-triggered as before. The unused `index` prop was removed from `Row`.

### Hydration fix
Replaced the `useState` + `useEffect` resize listener in `ProjectPage` with `useSyncExternalStore`, which provides a proper server-side snapshot and eliminates the hydration mismatch on initial render. The `navHeight` `ResizeObserver` was also removed following the layout refactor.

### Background color
`body` background now reads from the `--bg-color` CSS variable sourced from the Sanity color query, replacing hardcoded commented-out values.

### CSS fix
Corrected an overly broad `#tagline, p:first-of-type` selector to the intended `#tagline p:first-of-type`.

### Dead code removal
Deleted a large block of commented-out gallery rendering code from `ProjectPageGallery`.
