### PR TITLE
Single Featured Image

### DIFF
--- a/src/app/components/Row.tsx
+++ b/src/app/components/Row.tsx
@@ -1,11 +1,11 @@
-import { SinglePortfolioProject } from "../lib/types";
+import { LandingPortfolioQueryResult } from "@/sanity/types";
 import Image from "next/image";
 import { urlFor } from "@/sanity/lib/image";
 import Link from "next/link";
 
 
 interface RowProps {
-  project: SinglePortfolioProject,
+  project: LandingPortfolioQueryResult[number],
 }
 
 const Row: React.FC<RowProps> = ({ project }) => {
@@ -17,9 +17,51 @@ const Row: React.FC<RowProps> = ({ project }) => {
       style={{ opacity: 0 }}
         href={`/${project.slug}`}
     >
-      <div className={`left-img relative h-screen ${!project.photos?.[1] ? 'md:col-span-2' : ''}`}>
-        {project.photos && project.photos[0] &&
-          <Image
+      { project.photos?.length === 2 ?
+        <>
+          <div className={`left-img relative h-screen ${!project.photos?.[1] ? 'md:col-span-2' : ''}`}>
+            {project.photos && project.photos[0] &&
+              <Image
+                  src={urlFor(project.photos[0])
+                    .width(1000)
+                    .dpr(2)
+                    .quality(75)
+                    .url()
+                  }
+                  placeholder="blur"
+                  fill
+                  sizes="(max-width: 768px) 100vw, 50vw"
+                  alt={`Photo of ${project.projectName}`}
+                  blurDataURL={project.photos[0].asset?.metadata?.lqip}
+                  quality={75}
+                  className="object-cover "
+                />
+              }
+          </div>
+          <div className="right-img hidden md:block relative h-screen">
+            {project.photos && project.photos[1] &&
+              <Image
+                src={urlFor(project.photos[1])
+                  .width(1000)
+                  .dpr(2)
+                  .quality(75)
+                  .url()
+                }
+                placeholder="blur"
+                fill
+                sizes="(max-width: 768px) 100vw, 50vw"
+                alt={`Photo of ${project.projectName}`}
+                blurDataURL={project.photos[1].asset?.metadata?.lqip}
+                quality={75}
+                className="object-cover "
+              />
+            }
+          </div>
+        </>
+      :
+        <div className={`full-row relative h-screen ${!project.photos?.[1] ? 'md:col-span-2' : ''}`}>
+          {project.photos && project.photos[0] &&
+            <Image
               src={urlFor(project.photos[0])
                 .width(1000)
                 .dpr(2)
@@ -28,33 +70,15 @@ const Row: React.FC<RowProps> = ({ project }) => {
               }
               placeholder="blur"
               fill
-              sizes="(max-width: 768px) 100vw, 50vw"
+              sizes="(max-width: 768px) 100vw"
               alt={`Photo of ${project.projectName}`}
               blurDataURL={project.photos[0].asset?.metadata?.lqip}
               quality={75}
               className="object-cover "
             />
           }
-      </div>
-      <div className="right-img hidden md:block relative h-screen">
-        {project.photos && project.photos[1] &&
-          <Image
-            src={urlFor(project.photos[1])
-              .width(1000)
-              .dpr(2)
-              .quality(75)
-              .url()
-            }
-            placeholder="blur"
-            fill
-            sizes="(max-width: 768px) 100vw, 50vw"
-            alt={`Photo of ${project.projectName}`}
-            blurDataURL={project.photos[1].asset?.metadata?.lqip}
-            quality={75}
-            className="object-cover "
-          />
-        }
-      </div>
+        </div>
+      }
       <div className="info-text text-white uppercase absolute w-full bottom-7 left-0 text-center leading-6">
         {project.projectName &&
         <span className="name-hover">{project.projectName}{project.projectLocation && `, ${project.projectLocation}`}</span>

--- a/src/app/lib/types.ts
+++ b/src/app/lib/types.ts
@@ -1,45 +1,6 @@
 import { SanityImageMetadata, SanityAssetSourceData } from "@/sanity/types";
 import { ImageCrop, ImageHotspot } from "sanity";
 
-export interface SinglePortfolioProject {
-  _id: string;
-  // orderRank: string | null;
-  projectName: string | null;
-  slug: string | null;
-  photoCredit: Array<{
-    photogName?: string;
-    photogUrl?: string;
-    _key: string;
-  }> | null;
-  projectLocation: string | null;
-  photos: Array<{
-    asset: {
-      _id: string;
-      _type: "sanity.imageAsset";
-      _createdAt: string;
-      _updatedAt: string;
-      _rev: string;
-      originalFilename?: string;
-      label?: string;
-      title?: string;
-      description?: string;
-      altText?: string;
-      sha1hash?: string;
-      extension?: string;
-      mimeType?: string;
-      size?: number;
-      assetId?: string;
-      uploadId?: string;
-      path?: string;
-      url?: string;
-      metadata?: SanityImageMetadata;
-      source?: SanityAssetSourceData;
-      hotspot?: ImageHotspot;
-      crop?: ImageCrop;
-    } | null;
-  }> | null;
-};
-
 export interface PhotogCredit {
   photogName: string;
   photoUrl?: string;

--- a/src/sanity/schemaTypes/portfolio.ts
+++ b/src/sanity/schemaTypes/portfolio.ts
@@ -57,13 +57,6 @@ export default defineType({
       type: 'boolean',
       description: 'Idenitfy select projects to appear on the home/landing page',
       initialValue: true,
-      validation: (rule) => rule.custom((value, context) => {
-        if (value !== true) return true;
-        const photos = (context.document?.photos as { featured?: boolean }[] | undefined) ?? [];
-        const featuredCount = photos.filter((p) => p.featured === true).length;
-        if (featuredCount !== 2) return 'You must mark exactly 2 photos as "Featured on Homepage" before featuring this project';
-        return true;
-      }),
     }),
     orderRankField({ type: 'category' }),
     defineField({


### PR DESCRIPTION
## Summary

- **Single-image homepage rows**: `Row.tsx` now conditionally renders a full-width single image when a project has exactly 1 featured photo, and the existing two-column layout when there are 2. Previously the component always rendered two columns regardless of how many photos were marked as featured.
- **Fixed `sizes` hint**: The single-image path now correctly advertises `100vw` instead of the inherited `50vw` from the two-column layout, so Next.js requests the appropriately sized image.
- **Correct prop type**: `RowProps` now uses `LandingPortfolioQueryResult[number]` (Sanity codegen) instead of the hand-rolled `SinglePortfolioProject` interface, which had `hotspot`/`crop` nested inside `asset` rather than as siblings — misaligning with both the actual query shape and what `urlFor` expects. `SinglePortfolioProject` has been removed.
- **Removed over-strict validation**: The custom Sanity Studio rule requiring exactly 2 featured photos before a project could be marked as featured has been dropped, allowing editors to feature a project with just 1 homepage photo.

## Test plan

- [x] Mark a project as `featured` in Studio with exactly 1 photo set to "Featured on Homepage" — homepage row should render full-width
- [x] Mark a project as `featured` in Studio with 2 photos set to "Featured on Homepage" — homepage row should render two-column
- [x] Confirm blur placeholders and hotspot cropping render correctly on both layouts
- [x] Verify no TypeScript errors (`npx tsc --noEmit`)
