### PR TITLE
Homepage order and photo orientation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 
 # production
 /build
+/dist
 
 # misc
 .DS_Store

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@types/react-dom": "19.2.3",
         "eslint": "^9",
         "eslint-config-next": "16.1.6",
+        "localtunnel": "^2.0.2",
         "postcss": "^8",
         "tailwindcss": "^3.4.1",
         "typescript": "^5"
@@ -8546,6 +8547,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.14.0"
+      }
+    },
     "node_modules/axobject-query": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -13501,6 +13512,114 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/localtunnel": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/localtunnel/-/localtunnel-2.0.2.tgz",
+      "integrity": "sha512-n418Cn5ynvJd7m/N1d9WVJISLJF/ellZnfsLnx8WBWGzxv/ntNcFkJ1o6se5quUhCplfLGBNL5tYHiq5WF3Nug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "axios": "0.21.4",
+        "debug": "4.3.2",
+        "openurl": "1.1.1",
+        "yargs": "17.1.1"
+      },
+      "bin": {
+        "lt": "bin/lt.js"
+      },
+      "engines": {
+        "node": ">=8.3.0"
+      }
+    },
+    "node_modules/localtunnel/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/localtunnel/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/localtunnel/node_modules/debug": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/localtunnel/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/localtunnel/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/localtunnel/node_modules/yargs": {
+      "version": "17.1.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.1.1.tgz",
+      "integrity": "sha512-c2k48R0PwKIqKhPMWjeiF6y2xY/gPMUlro0sgxqXpbOIohWiLNXWslsootttv7E1e73QPAMQSg5FeySbVcpsPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/localtunnel/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -14411,6 +14530,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/openurl": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/openurl/-/openurl-1.1.1.tgz",
+      "integrity": "sha512-d/gTkTb1i1GKz5k3XE3XFV/PxQ1k45zDqGP2OA7YhgsaLoqm6qRvARAZOFer1fcXritWlGBRCu/UgeS4HAnXAA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/optionator": {
       "version": "0.9.4",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@types/react-dom": "19.2.3",
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
+    "localtunnel": "^2.0.2",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"

--- a/schema.json
+++ b/schema.json
@@ -439,6 +439,23 @@
                 },
                 "optional": true
               },
+              "orientation": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "union",
+                  "of": [
+                    {
+                      "type": "string",
+                      "value": "landscape"
+                    },
+                    {
+                      "type": "string",
+                      "value": "vertical"
+                    }
+                  ]
+                },
+                "optional": true
+              },
               "_type": {
                 "type": "objectAttribute",
                 "value": {
@@ -466,6 +483,13 @@
         "type": "objectAttribute",
         "value": {
           "type": "boolean"
+        },
+        "optional": true
+      },
+      "homepageOrder": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "number"
         },
         "optional": true
       },

--- a/src/app/components/PortfolioGridTile.tsx
+++ b/src/app/components/PortfolioGridTile.tsx
@@ -1,10 +1,10 @@
-import { ProjectQueryResult } from "@/sanity/types"
+import { PortfolioQueryResult } from "@/sanity/types"
 import { urlFor } from "@/sanity/lib/image"
 import Link from "next/link"
 import Image from "next/image"
 
 interface TileProps {
-  project: ProjectQueryResult,
+  project: PortfolioQueryResult[number],
 }
 
 const PortfolioGridTile: React.FC<TileProps> = ({ project }) => {

--- a/src/app/components/ProjectPageGallery.tsx
+++ b/src/app/components/ProjectPageGallery.tsx
@@ -43,7 +43,7 @@ export default function ProjectPageGallery({groups, projectName, isMobile}: Gall
                   alt={`Photo of ${projectName ?? "project"}`}
                   blurDataURL={group.images[0].asset?.metadata?.lqip}
                   quality={100}
-                  className="object-cover"
+                  className={group.images[0].orientation === "vertical" ? "object-contain" : "object-cover"}
                   priority={groupIdx === 0}
                 />}
               </div>
@@ -78,7 +78,7 @@ export default function ProjectPageGallery({groups, projectName, isMobile}: Gall
                         alt={`Photo of ${projectName ?? "project"}`}
                         blurDataURL={img.asset?.metadata?.lqip}
                         quality={75}
-                        className="object-cover"
+                        className={img.orientation === "vertical" ? "object-contain" : "object-cover"}
                         priority={groupIdx === 0}
                       />}
                     </div>
@@ -115,7 +115,7 @@ export default function ProjectPageGallery({groups, projectName, isMobile}: Gall
                       alt={`Photo of ${projectName ?? "project"}`}
                       blurDataURL={img.asset?.metadata?.lqip}
                       quality={75}
-                      className="object-cover"
+                      className={img.orientation === "vertical" ? "object-contain" : "object-cover"}
                       priority={groupIdx === 0}
                     />}
                   </div>

--- a/src/app/lib/queries.ts
+++ b/src/app/lib/queries.ts
@@ -18,7 +18,7 @@ export const portfolioQuery = defineQuery(
 );
 
 export const landingPortfolioQuery = defineQuery(
-  `*[_type == "portfolio" && featured == true]{
+  `*[_type == "portfolio" && featured == true] | order(coalesce(homepageOrder, 9999) asc){
     _id,
     projectName,
     "slug": slug.current,
@@ -79,7 +79,8 @@ export const projectQuery = defineQuery(
       photos[]{
         asset ->,
         hotspot,
-        crop
+        crop,
+        orientation
       },
       projectType,
   }`

--- a/src/app/lib/queries.ts
+++ b/src/app/lib/queries.ts
@@ -18,7 +18,7 @@ export const portfolioQuery = defineQuery(
 );
 
 export const landingPortfolioQuery = defineQuery(
-  `*[_type == "portfolio" && featured == true] | order(coalesce(homepageOrder, 9999) asc){
+  `*[_type == "portfolio" && featured == true && count(photos[featured == true]) > 0] | order(coalesce(homepageOrder, 9999) asc){
     _id,
     projectName,
     "slug": slug.current,

--- a/src/app/lib/types.ts
+++ b/src/app/lib/types.ts
@@ -58,4 +58,5 @@ export interface AllImageArray {
     hotspot?: ImageHotspot | null;
     crop?: ImageCrop | null;
   } | null;
+  orientation?: "landscape" | "vertical" | null;
 }

--- a/src/app/lib/util.ts
+++ b/src/app/lib/util.ts
@@ -13,16 +13,8 @@ export const imageShuffler = <T,>(array: T[]) => {
   return shuffledImgs;
 }
 
-export const shuffle = (array: LandingPortfolioQueryResult) => {
-  const len = array.length;
-  const shuffled = array.slice();
-  for (let i = len - 1; i > 0; i -= 1){
-    const rando = Math.floor(Math.random() * (i + 1));
-    const current = shuffled[i];
-    shuffled[i] = shuffled[rando];
-    shuffled[rando] = current
-  };
-  return shuffled.map(proj => ({
+export const shufflePhotos = (array: LandingPortfolioQueryResult) => {
+  return array.map(proj => ({
     ...proj,
     photos: imageShuffler(proj.photos ?? [])
   }));

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
 import { LandingPortfolioQueryResult } from "@/sanity/types";
-import { shuffle } from "./lib/util";
+import { shufflePhotos } from "./lib/util";
 import { landingPortfolioQuery } from "./lib/queries";
 import { sanityFetch } from "./lib/sanityFetch";
 import Homepage from "./components/Homepage";
@@ -13,10 +13,10 @@ const portfolio: LandingPortfolioQueryResult = await sanityFetch<LandingPortfoli
 
 export default async function Home() {
 
-  const shuffledPortfolio = shuffle(portfolio)
+  const orderedPortfolio = shufflePhotos(portfolio)
 
 
   return (
-    <Homepage portfolio={shuffledPortfolio} />
+    <Homepage portfolio={orderedPortfolio} />
   );
 }

--- a/src/sanity/schemaTypes/portfolio.ts
+++ b/src/sanity/schemaTypes/portfolio.ts
@@ -58,10 +58,14 @@ export default defineType({
           }),
         ],
       }],
-      validation: (rule) => rule.custom((photos) => {
+      validation: (rule) => rule.custom((photos, context) => {
         if (!Array.isArray(photos)) return true;
         const featuredCount = (photos as { featured?: boolean }[]).filter((p) => p.featured === true).length;
         if (featuredCount > 2) return 'Only 2 images per project can be featured on the homepage';
+        const document = context.document as SanityDocument & { featured?: boolean };
+        if (document?.featured && featuredCount < 1) {
+          return 'Select at least 1 photo to feature before this project can appear on the homepage';
+        }
         return true;
       }),
     }),

--- a/src/sanity/schemaTypes/portfolio.ts
+++ b/src/sanity/schemaTypes/portfolio.ts
@@ -124,4 +124,23 @@ export default defineType({
       validation: (rule) => rule.required(),
     }),
   ],
+  preview: {
+    select: {
+      title: 'projectName',
+      featured: 'featured',
+      homepageOrder: 'homepageOrder',
+    },
+    prepare({ title, featured, homepageOrder }) {
+      const subtitle = !featured
+        ? 'Not on homepage'
+        : typeof homepageOrder === 'number'
+          ? `On homepage — #${homepageOrder}`
+          : 'On homepage — order not set';
+
+      return {
+        title: title || 'Untitled project',
+        subtitle,
+      };
+    },
+  },
 })

--- a/src/sanity/schemaTypes/portfolio.ts
+++ b/src/sanity/schemaTypes/portfolio.ts
@@ -42,6 +42,20 @@ export default defineType({
             description: 'Feature this image on the homepage if project is selected to feature on homepage (max 2 per project)',
             initialValue: false,
           }),
+          defineField({
+            name: 'orientation',
+            title: 'Display As',
+            type: 'string',
+            description: 'On the project page, Landscape crops this photo to fill the row edge-to-edge. Vertical shows the whole photo uncropped, letterboxed on the background color.',
+            options: {
+              list: [
+                { title: 'Landscape (crop to fill)', value: 'landscape' },
+                { title: 'Vertical (show full photo)', value: 'vertical' },
+              ],
+              layout: 'radio',
+            },
+            initialValue: 'landscape',
+          }),
         ],
       }],
       validation: (rule) => rule.custom((photos) => {
@@ -57,6 +71,13 @@ export default defineType({
       type: 'boolean',
       description: 'Idenitfy select projects to appear on the home/landing page',
       initialValue: true,
+    }),
+    defineField({
+      name: 'homepageOrder',
+      title: 'Homepage Order',
+      type: 'number',
+      description: 'Controls where this project appears on the homepage (lower numbers appear first). Only applies when Featured is on. Leave blank to show after ordered projects.',
+      hidden: ({ document }) => !document?.featured,
     }),
     orderRankField({ type: 'category' }),
     defineField({

--- a/src/sanity/schemaTypes/portfolio.ts
+++ b/src/sanity/schemaTypes/portfolio.ts
@@ -75,6 +75,15 @@ export default defineType({
       type: 'boolean',
       description: 'Idenitfy select projects to appear on the home/landing page',
       initialValue: true,
+      validation: (rule) => rule.custom((featured, context) => {
+        if (!featured) return true;
+        const document = context.document as SanityDocument & { photos?: { featured?: boolean }[] };
+        const featuredPhotoCount = (document?.photos ?? []).filter((p) => p?.featured === true).length;
+        if (featuredPhotoCount < 1) {
+          return 'Mark at least 1 photo as "Featured on Homepage" in the Photos section before turning this on';
+        }
+        return true;
+      }),
     }),
     defineField({
       name: 'homepageOrder',

--- a/src/sanity/types.ts
+++ b/src/sanity/types.ts
@@ -346,7 +346,7 @@ export type PortfolioQueryResult = Array<{
 
 // Source: src/app/lib/queries.ts
 // Variable: landingPortfolioQuery
-// Query: *[_type == "portfolio" && featured == true] | order(coalesce(homepageOrder, 9999) asc){    _id,    projectName,    "slug": slug.current,    photoCredit,    projectLocation,    photos[featured == true]{      asset ->,      hotspot,      crop    },    projectType,    featured,  }
+// Query: *[_type == "portfolio" && featured == true && count(photos[featured == true]) > 0] | order(coalesce(homepageOrder, 9999) asc){    _id,    projectName,    "slug": slug.current,    photoCredit,    projectLocation,    photos[featured == true]{      asset ->,      hotspot,      crop    },    projectType,    featured,  }
 export type LandingPortfolioQueryResult = Array<{
   _id: string;
   projectName: string | null;
@@ -384,7 +384,7 @@ export type LandingPortfolioQueryResult = Array<{
     crop: SanityImageCrop | null;
   }> | null;
   projectType: string | null;
-  featured: true;
+  featured: boolean | null;
 }>;
 
 // Source: src/app/lib/queries.ts
@@ -522,7 +522,7 @@ import "@sanity/client";
 declare module "@sanity/client" {
   interface SanityQueries {
     '*[_type == "portfolio"] | order(orderRank){\n    _id,\n    projectName,\n    "slug": slug.current,\n    photoCredit,\n    projectLocation,\n    photos[]{\n      asset ->,\n      hotspot,\n      crop\n    },\n    projectType,\n  }': PortfolioQueryResult;
-    '*[_type == "portfolio" && featured == true] | order(coalesce(homepageOrder, 9999) asc){\n    _id,\n    projectName,\n    "slug": slug.current,\n    photoCredit,\n    projectLocation,\n    photos[featured == true]{\n      asset ->,\n      hotspot,\n      crop\n    },\n    projectType,\n    featured,\n  }': LandingPortfolioQueryResult;
+    '*[_type == "portfolio" && featured == true && count(photos[featured == true]) > 0] | order(coalesce(homepageOrder, 9999) asc){\n    _id,\n    projectName,\n    "slug": slug.current,\n    photoCredit,\n    projectLocation,\n    photos[featured == true]{\n      asset ->,\n      hotspot,\n      crop\n    },\n    projectType,\n    featured,\n  }': LandingPortfolioQueryResult;
     "*[_type == 'tagline'][0]{\n    copy,\n  }": TaglineQueryResult;
     "*[_type == 'contact'][0]{\n    emailAddy,\n    instagram,\n    location,\n  }": ContactQueryResult;
     "*[_type == 'infoPage'][0]{\n    portrait{\n      credit,\n      creditUrl,\n      asset ->,\n      hotspot,\n      crop\n    },\n    pressContact\n  }": InfoPageQueryResult;

--- a/src/sanity/types.ts
+++ b/src/sanity/types.ts
@@ -78,10 +78,12 @@ export type Portfolio = {
     hotspot?: SanityImageHotspot;
     crop?: SanityImageCrop;
     featured?: boolean;
+    orientation?: "landscape" | "vertical";
     _type: "image";
     _key: string;
   }>;
   featured?: boolean;
+  homepageOrder?: number;
   orderRank?: string;
   projectLocation?: string;
   role?: string;
@@ -344,7 +346,7 @@ export type PortfolioQueryResult = Array<{
 
 // Source: src/app/lib/queries.ts
 // Variable: landingPortfolioQuery
-// Query: *[_type == "portfolio" && featured == true]{    _id,    projectName,    "slug": slug.current,    photoCredit,    projectLocation,    photos[featured == true]{      asset ->,      hotspot,      crop    },    projectType,    featured,  }
+// Query: *[_type == "portfolio" && featured == true] | order(coalesce(homepageOrder, 9999) asc){    _id,    projectName,    "slug": slug.current,    photoCredit,    projectLocation,    photos[featured == true]{      asset ->,      hotspot,      crop    },    projectType,    featured,  }
 export type LandingPortfolioQueryResult = Array<{
   _id: string;
   projectName: string | null;
@@ -474,7 +476,7 @@ export type AllProjectSlugsQueryResult = Array<{
 
 // Source: src/app/lib/queries.ts
 // Variable: projectQuery
-// Query: *[_type == 'portfolio' && slug.current == $slug][0]{      _id,      projectName,      "slug": slug.current,      photoCredit,      projectLocation,      photos[]{        asset ->,        hotspot,        crop      },      projectType,  }
+// Query: *[_type == 'portfolio' && slug.current == $slug][0]{      _id,      projectName,      "slug": slug.current,      photoCredit,      projectLocation,      photos[]{        asset ->,        hotspot,        crop,        orientation      },      projectType,  }
 export type ProjectQueryResult = {
   _id: string;
   projectName: string | null;
@@ -510,6 +512,7 @@ export type ProjectQueryResult = {
     } | null;
     hotspot: SanityImageHotspot | null;
     crop: SanityImageCrop | null;
+    orientation: "landscape" | "vertical" | null;
   }> | null;
   projectType: string | null;
 } | null;
@@ -519,12 +522,12 @@ import "@sanity/client";
 declare module "@sanity/client" {
   interface SanityQueries {
     '*[_type == "portfolio"] | order(orderRank){\n    _id,\n    projectName,\n    "slug": slug.current,\n    photoCredit,\n    projectLocation,\n    photos[]{\n      asset ->,\n      hotspot,\n      crop\n    },\n    projectType,\n  }': PortfolioQueryResult;
-    '*[_type == "portfolio" && featured == true]{\n    _id,\n    projectName,\n    "slug": slug.current,\n    photoCredit,\n    projectLocation,\n    photos[featured == true]{\n      asset ->,\n      hotspot,\n      crop\n    },\n    projectType,\n    featured,\n  }': LandingPortfolioQueryResult;
+    '*[_type == "portfolio" && featured == true] | order(coalesce(homepageOrder, 9999) asc){\n    _id,\n    projectName,\n    "slug": slug.current,\n    photoCredit,\n    projectLocation,\n    photos[featured == true]{\n      asset ->,\n      hotspot,\n      crop\n    },\n    projectType,\n    featured,\n  }': LandingPortfolioQueryResult;
     "*[_type == 'tagline'][0]{\n    copy,\n  }": TaglineQueryResult;
     "*[_type == 'contact'][0]{\n    emailAddy,\n    instagram,\n    location,\n  }": ContactQueryResult;
     "*[_type == 'infoPage'][0]{\n    portrait{\n      credit,\n      creditUrl,\n      asset ->,\n      hotspot,\n      crop\n    },\n    pressContact\n  }": InfoPageQueryResult;
     "*[_type == 'bgColor'][0]": BgColorQueryResult;
     '*[_type == "portfolio" && defined(slug.current)]{ "slug": slug.current }': AllProjectSlugsQueryResult;
-    "*[_type == 'portfolio' && slug.current == $slug][0]{\n      _id,\n      projectName,\n      \"slug\": slug.current,\n      photoCredit,\n      projectLocation,\n      photos[]{\n        asset ->,\n        hotspot,\n        crop\n      },\n      projectType,\n  }": ProjectQueryResult;
+    "*[_type == 'portfolio' && slug.current == $slug][0]{\n      _id,\n      projectName,\n      \"slug\": slug.current,\n      photoCredit,\n      projectLocation,\n      photos[]{\n        asset ->,\n        hotspot,\n        crop,\n        orientation\n      },\n      projectType,\n  }": ProjectQueryResult;
   }
 }


### PR DESCRIPTION
## Summary
- Add homepage-specific project ordering via a new `homepageOrder` field, replacing the random shuffle that previously determined homepage layout
- Add a per-photo Landscape/Vertical display toggle so individual project pages can show a photo full-frame (letterboxed) instead of always cropping to fill
- Surface each project's homepage placement (e.g. "On homepage — #2", "Not on homepage") directly in the Studio's Portfolio list, so it's visible at a glance without opening each document
- Add two failsafes against the "blank homepage row" bug (previously required manual cleanup — see 4/21 email thread): Studio validation blocks publishing a Featured project with zero featured photos, and the homepage query independently filters out any project with no featured photos regardless of validation state
- Fix a pre-existing type mismatch in `PortfolioGridTile` (was typed against the wrong query result, surfaced by the schema regen)

## Test plan
- [x] `npm run build` passes against live Sanity data
- [x] `npx tsc --noEmit` passes
- [x] In Studio: toggle Featured on a project with no featured photos → Publish is blocked with a validation message
- [x] Set Homepage Order values across a few featured projects → homepage reflects that order (not random)
- [ ] Mark a project photo "Vertical" → project detail page renders it uncropped/letterboxed rather than cropped
- [x] Portfolio list in Studio shows the homepage-placement subtitle under each project name